### PR TITLE
Enable serialization of includes for collection resources

### DIFF
--- a/spec/__snapshots__/serialize.spec.js.snap
+++ b/spec/__snapshots__/serialize.spec.js.snap
@@ -413,16 +413,41 @@ Object {
 }
 `;
 
-exports[`serialize with simple attributes with an array of resources and attributes ignores the attributes and only serializes id and type 1`] = `
+exports[`serialize with simple attributes with an array of resources and attributes serializes the data 1`] = `
 Object {
   "data": Array [
     Object {
+      "attributes": Object {
+        "firstName": "Nico",
+        "lastName": "Peters",
+      },
       "id": "123",
       "type": "user",
     },
     Object {
+      "attributes": Object {
+        "firstName": "Frank",
+        "lastName": "Wüller",
+      },
       "id": "134",
+      "relationships": Object {
+        "company": Object {
+          "data": Object {
+            "id": "66",
+            "type": "companies",
+          },
+        },
+      },
       "type": "user",
+    },
+  ],
+  "included": Array [
+    Object {
+      "attributes": Object {
+        "name": "Compeon",
+      },
+      "id": "66",
+      "type": "companies",
     },
   ],
 }

--- a/spec/serialize.spec.js
+++ b/spec/serialize.spec.js
@@ -66,9 +66,6 @@ describe('serialize', () => {
       })
     })
 
-    // An array is not allowed as a root level resource, but it can be used to
-    // update relationships. In this case attributes will be ignored.
-    // http://jsonapi.org/format/#crud-updating-relationships
     describe('with an array of resources and attributes', () => {
       const data = [
         {
@@ -79,16 +76,27 @@ describe('serialize', () => {
         {
           id: '134',
           firstName: 'Frank',
-          lastName: 'Wüller'
+          lastName: 'Wüller',
+          company: {
+            id: '66',
+            name: 'Compeon'
+          }
+
         }
       ]
       const options = {
-        attributes: ['firstName', 'lastName']
+        attributes: ['company', 'firstName', 'lastName'],
+        relationships: {
+          company: {
+            attributes: ['name'],
+            type: 'companies'
+          }
+        }
       }
 
       const userSerializer = serialize('user', options)
 
-      it('ignores the attributes and only serializes id and type', () => {
+      it('serializes the data', () => {
         expect(userSerializer(data)).toMatchSnapshot()
       })
     })


### PR DESCRIPTION
This will enable serialization of attributes and includes for collection resources.
It won't break anything in other apps, but will produce an overhead for `relationship` resources, as these wouldn't need attributes.

We need to talk about a proper concept for configuring the serializer in the near future.

