### PR TITLE
Support polymorph relationships for serialization

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ const data = {
     name: 'Earth'
   },
   orbiters: [
-    withPolymorphicType('satellites', [{
+    withPolymorphicType('satellites', {
       id: '42',
       name: 'Not So Deep Thought'
     })

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,12 @@ const data = {
     // or
     lid: '79862106-6aac-4a66-9553-d1453fc267de',
     name: 'Earth'
-  }
+  },
+  orbiters: [{
+    id: '42',
+    _type: 'satellites',
+    name: 'Not So Deep Thought'
+  }]
 }
 
 const options = {
@@ -49,6 +54,10 @@ const options = {
     planet: {
       attributes: ['name'],
       type: 'planets'
+    },
+    orbiters: {
+      attributes: ['name'],
+      type: 'polymorphic'
     }
   }
 }
@@ -76,6 +85,14 @@ will serialize to
           lid: '79862106-6aac-4a66-9553-d1453fc267de',
           type: 'planets'
         }
+      },
+      orbiters: {
+        data: [
+          {
+            id: '42',
+            type: 'satellites'
+          }
+        ]
       }
     }
   },
@@ -87,6 +104,13 @@ will serialize to
       type: 'planets',
       attributes: {
         name: 'Earth'
+      }
+    },
+    {
+      id: '42',
+      type: 'satellites',
+      attributes: {
+        name: 'Not So Deep Thought'
       }
     }
   ]

--- a/readme.md
+++ b/readme.md
@@ -41,11 +41,21 @@ const data = {
     lid: '79862106-6aac-4a66-9553-d1453fc267de',
     name: 'Earth'
   },
-  orbiters: [{
-    id: '42',
-    _type: 'satellites',
-    name: 'Not So Deep Thought'
-  }]
+  orbiters: [
+    withPolymorphicType('satellites', [{
+      id: '42',
+      name: 'Not So Deep Thought'
+    })
+  ]
+  // alternatively you may apply the type to all entries in the relationship:
+  // orbiters: withPolymorphicType('satellites', [
+  //   {
+  //     id: '42',
+  //     name: 'Not So Deep Thought'
+  //   },
+  //   ...
+  // ])
+  )
 }
 
 const options = {

--- a/spec/__snapshots__/serialize.spec.js.snap
+++ b/spec/__snapshots__/serialize.spec.js.snap
@@ -223,6 +223,18 @@ Object {
     },
     "id": "511",
     "relationships": Object {
+      "colleagues": Object {
+        "data": Array [
+          Object {
+            "id": "777",
+            "type": "users",
+          },
+          Object {
+            "id": "333",
+            "type": "users",
+          },
+        ],
+      },
       "organizations": Object {
         "data": Array [
           Object {

--- a/spec/__snapshots__/serialize.spec.js.snap
+++ b/spec/__snapshots__/serialize.spec.js.snap
@@ -51,6 +51,27 @@ Object {
 }
 `;
 
+exports[`serialize with a 1:1 relationship with a polymorphic relationship serializes the data 1`] = `
+Object {
+  "data": Object {
+    "attributes": Object {
+      "firstName": "Nico",
+      "lastName": "Peters",
+    },
+    "id": "511",
+    "relationships": Object {
+      "organization": Object {
+        "data": Object {
+          "id": "666",
+          "type": "companies",
+        },
+      },
+    },
+    "type": "users",
+  },
+}
+`;
+
 exports[`serialize with a 1:1 relationship with includes with a local id serializes the data 1`] = `
 Object {
   "data": Object {
@@ -184,6 +205,33 @@ Object {
           Object {
             "id": "667",
             "type": "companies",
+          },
+        ],
+      },
+    },
+    "type": "users",
+  },
+}
+`;
+
+exports[`serialize with a 1:n relationship with a polymorphic relationship serializes the data 1`] = `
+Object {
+  "data": Object {
+    "attributes": Object {
+      "firstName": "Nico",
+      "lastName": "Peters",
+    },
+    "id": "511",
+    "relationships": Object {
+      "organizations": Object {
+        "data": Array [
+          Object {
+            "id": "666",
+            "type": "companies",
+          },
+          Object {
+            "id": "667",
+            "type": "multiplier-organizations",
           },
         ],
       },

--- a/spec/serialize.spec.js
+++ b/spec/serialize.spec.js
@@ -129,6 +129,33 @@ describe('serialize', () => {
       })
     })
 
+    describe('with a polymorphic relationship', () => {
+      const data = {
+        id: '511',
+        firstName: 'Nico',
+        lastName: 'Peters',
+        organization: {
+          id: '666',
+          name: 'Compeon GmbH',
+          _type: 'companies'
+        }
+      }
+      const options = {
+        attributes: ['organization', 'firstName', 'lastName'],
+        relationships: {
+          organization: {
+            type: 'polymorphic'
+          }
+        }
+      }
+
+      const serializeUser = serialize('users', options)
+
+      it('serializes the data', () => {
+        expect(serializeUser(data)).toMatchSnapshot()
+      })
+    })
+
     describe('with a local id', () => {
       const data = {
         id: '511',
@@ -256,6 +283,40 @@ describe('serialize', () => {
         relationships: {
           companies: {
             type: 'companies'
+          }
+        }
+      }
+
+      const serializeUser = serialize('users', options)
+
+      it('serializes the data', () => {
+        expect(serializeUser(data)).toMatchSnapshot()
+      })
+    })
+
+    describe('with a polymorphic relationship', () => {
+      const data = {
+        id: '511',
+        firstName: 'Nico',
+        lastName: 'Peters',
+        organizations: [
+          {
+            id: '666',
+            name: 'Compeon GmbH',
+            _type: 'companies'
+          },
+          {
+            id: '667',
+            name: 'Compeon 4.0 GmbH',
+            _type: 'multiplier-organizations'
+          }
+        ]
+      }
+      const options = {
+        attributes: ['organizations', 'firstName', 'lastName'],
+        relationships: {
+          organizations: {
+            type: 'polymorphic'
           }
         }
       }
@@ -510,6 +571,29 @@ describe('serialize', () => {
         attributes: ['company'],
         relationships: {
           company: {
+          }
+        }
+      }
+
+      const userSerializer = serialize('users', options)
+
+      it('throws an error', () => {
+        expect(() => userSerializer(data)).toThrowError()
+      })
+    })
+
+    describe('when no relationship type is set for a polymorphic relationship', () => {
+      const data = {
+        id: '123',
+        organization: {
+          id: '612'
+        }
+      }
+      const options = {
+        attributes: ['organization'],
+        relationships: {
+          organization: {
+            type: 'polymorphic'
           }
         }
       }

--- a/spec/serialize.spec.js
+++ b/spec/serialize.spec.js
@@ -1,4 +1,5 @@
 import { serialize } from 'serialize'
+import { withPolymorphicType } from 'common'
 
 describe('serialize', () => {
   describe('with simple attributes', () => {
@@ -134,11 +135,10 @@ describe('serialize', () => {
         id: '511',
         firstName: 'Nico',
         lastName: 'Peters',
-        organization: {
+        organization: withPolymorphicType('companies', {
           id: '666',
-          name: 'Compeon GmbH',
-          _type: 'companies'
-        }
+          name: 'Compeon GmbH'
+        })
       }
       const options = {
         attributes: ['organization', 'firstName', 'lastName'],
@@ -300,22 +300,27 @@ describe('serialize', () => {
         firstName: 'Nico',
         lastName: 'Peters',
         organizations: [
-          {
+          withPolymorphicType('companies', {
             id: '666',
-            name: 'Compeon GmbH',
-            _type: 'companies'
-          },
-          {
+            name: 'Compeon GmbH'
+          }),
+          withPolymorphicType('multiplier-organizations', {
             id: '667',
-            name: 'Compeon 4.0 GmbH',
-            _type: 'multiplier-organizations'
-          }
-        ]
+            name: 'Compeon 4.0 GmbH'
+          })
+        ],
+        colleagues: withPolymorphicType('users', [
+          { id: '777', name: 'Arno Admin' },
+          { id: '333', name: 'Ben Utzer' }
+        ])
       }
       const options = {
-        attributes: ['organizations', 'firstName', 'lastName'],
+        attributes: ['organizations', 'colleagues', 'firstName', 'lastName'],
         relationships: {
           organizations: {
+            type: 'polymorphic'
+          },
+          colleagues: {
             type: 'polymorphic'
           }
         }

--- a/src/common.js
+++ b/src/common.js
@@ -21,3 +21,13 @@ export const renderIdentifier = ({ name, value, valid }) => {
   if (!valid) return {}
   return { [name]: value }
 }
+
+export const COMPEON_API_JS_TYPE = Symbol('COMPEON_API_JS_TYPE')
+
+export const withPolymorphicType = (type, obj) => {
+  if (Array.isArray(obj)) {
+    return obj.map(entry => withPolymorphicType(type, entry))
+  } else {
+    return Object.assign(obj, { [COMPEON_API_JS_TYPE]: type })
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
 export { deserialize } from './deserialize'
 export { serialize } from './serialize'
+export { withPolymorphicType } from './common'

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -76,6 +76,10 @@ const serializeResource = (type, resource, options, root = false) => {
   const attributeOptions = options.attributes || []
   const relationshipOptions = options.relationships || {}
   const relationshipNames = Object.keys(relationshipOptions)
+  const isPolymorphic = type === 'polymorphic'
+
+  if (isPolymorphic) attributeOptions.push('_type')
+
   const {
     attributes,
     identifier,
@@ -85,6 +89,15 @@ const serializeResource = (type, resource, options, root = false) => {
     included,
     relationships: serializedRelationships
   } = serializeRelationships(relationships, relationshipOptions)
+
+  if (isPolymorphic) {
+    if (!attributes._type) {
+      throw `You did not specify a _type for the relationship to the object with id "${identifier}"`
+    }
+
+    type = attributes._type
+    delete attributes._type
+  }
 
   if (root) {
     return renderResource(

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -92,7 +92,7 @@ const serializeResource = (type, resource, options, root = false) => {
 
   if (type === 'polymorphic') {
     if (polymorphicType) type = polymorphicType
-    else throw `You did not specify a type for the resource with id ${identifier}.`
+    else throw `You did not specify a type for the resource with ${identifier.name} ${identifier.value}.`
   }
 
   if (root) {

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -91,8 +91,15 @@ const serializeResource = (type, resource, options, root = false) => {
   } = serializeRelationships(relationships, relationshipOptions)
 
   if (type === 'polymorphic') {
-    if (polymorphicType) type = polymorphicType
-    else throw `You did not specify a type for the resource with ${identifier.name} ${identifier.value}.`
+    if (root) throw 'You should use separate serializers to render different root resources.'
+
+    if (polymorphicType) {
+      type = polymorphicType
+    } else if (identifier.valid) {
+      throw `You did not specify a type for the resource with ${identifier.name} ${identifier.value}.`
+    } else {
+      throw 'You did not specify a type for one of the polymorphic resources.'
+    }
   }
 
   if (root) {


### PR DESCRIPTION
# Polymorphic Relationships in Compeon-Api-Js
## Suggestion A
- In the relationships in a schema: change `type: string` to `type: string | (object => string)`
- that function determins the type, dependent on the respective entity
### Pros
- very dynamic
- can handle mixed-type relationships
### Cons
- no solution for when the type cannot be determined just with the entity alone
### Example 
```
// in the schema:
  ...
  relationships: { 
    attachment: { 
      type: entity => entity.attributes.someAttribute ? 'Company' : 'CompeonOrganization'
    }
  }
```
## Suggestion B 
- In the relationships in a schema: `type: 'polymorphic'`
- `compeon-jsonapi-serializer` recognizes this type and looks for `_type` inside of `attributes` to set the type
### Pros
- very explicit
### Cons
- not very elegant
- apps have to remember to set the `_type`, the serializer loses control
### Example 
```
// in the schema:
  ...
  relationships: { attachment: { type: 'polymorphic' } } ...
  ...
// in an app that uses the api client:
  Attachment.create({ 
    _type: 'CompeonOrganization',
    virtualPath: 'Sonstige Unterlagen',
    ...
  })
```
The `create` Method has to add that `_type` to the attachment's aattributes
## Suggestion C
- have an own resource with own schema per relationship-type
### Pros 
- very explicit 
- serializer keeps control about what type to use
### Cons 
- code duplication 
- not very elegant 
### Example 
`CompeonAttachment.create`
## Suggestion D 
- the parent resources have methods per type, each of which uses an own serializer
### Pros
- like C 
### Cons 
- like C
### Example 
`Inquiry.addCompeonAttachment` and `Inquiry.addCompanyAttachment`