### PR TITLE
Include empty relationships on deserialization

### DIFF
--- a/spec/__snapshots__/deserialize.spec.js.snap
+++ b/spec/__snapshots__/deserialize.spec.js.snap
@@ -261,8 +261,10 @@ Array [
 ]
 `;
 
-exports[`deserialize with empty relationships ignores the relationship 1`] = `
+exports[`deserialize with empty relationships renders the empty relationships 1`] = `
 Object {
+  "colleagues": Array [],
+  "company": null,
   "firstName": "Nico",
   "id": "123",
   "lastName": "Peters",
@@ -316,8 +318,9 @@ Object {
 }
 `;
 
-exports[`deserialize with relationships that have no identifier ignores the relationship 1`] = `
+exports[`deserialize with relationships that have no identifier renders an empty relationship 1`] = `
 Object {
+  "company": null,
   "firstName": "Nico",
   "id": "123",
   "lastName": "Peters",

--- a/spec/deserialize.spec.js
+++ b/spec/deserialize.spec.js
@@ -631,12 +631,15 @@ describe('deserialize', () => {
         relationships: {
           company: {
             data: null
+          },
+          colleagues: {
+            data: []
           }
         }
       }
     }
 
-    it('ignores the relationship', () => {
+    it('renders the empty relationships', () => {
       expect(deserialize()(json)).toMatchSnapshot()
     })
   })
@@ -668,7 +671,7 @@ describe('deserialize', () => {
       ]
     }
 
-    it('ignores the relationship', () => {
+    it('renders an empty relationship', () => {
       expect(deserialize()(json)).toMatchSnapshot()
     })
   })

--- a/src/deserialize.js
+++ b/src/deserialize.js
@@ -32,9 +32,12 @@ const deserializeRelationships = (relationships, included) => (
       deserializedResource = deserializeResources(data, included, links)
     } else if (isPlainObject(data)) {
       deserializedResource = deserializeResource(data, included, links)
+      if (isEmpty(deserializedResource)) deserializedResource = null
+    } else if (data == null) {
+      deserializedResource = null
     }
 
-    if (!isEmpty(deserializedResource)) result[key] = deserializedResource
+    result[key] = deserializedResource
 
     return result
   }, {})

--- a/src/deserialize.js
+++ b/src/deserialize.js
@@ -1,4 +1,5 @@
 import {
+  compact,
   find,
   get,
   isEmpty,
@@ -26,15 +27,13 @@ const deserializeRelationships = (relationships, included) => (
   reduce(relationships, (result, value, key) => {
     const data = get(value, 'data')
     const links = get(value, 'links')
-    let deserializedResource
+    let deserializedResource = null
 
     if (Array.isArray(data)) {
       deserializedResource = deserializeResources(data, included, links)
     } else if (isPlainObject(data)) {
       deserializedResource = deserializeResource(data, included, links)
       if (isEmpty(deserializedResource)) deserializedResource = null
-    } else if (data == null) {
-      deserializedResource = null
     }
 
     result[key] = deserializedResource
@@ -57,7 +56,7 @@ const deserializeResource = (resource, included, rootLinks, root = false) => {
   // Resources without a valid identifier are actually not specified, but
   // otherwise responses that are no resource and thus do not have a valid
   // identifier could not be deserialized.
-  if (!root && !identifier.valid) return {}
+  if (!root && !identifier.valid) return null
 
   return {
     ...renderIdentifier(identifier),
@@ -70,7 +69,7 @@ const deserializeResource = (resource, included, rootLinks, root = false) => {
 }
 
 const deserializeResources = (resources, included, rootLinks, root = false) => (
-  map(resources, resource => deserializeResource(resource, included, rootLinks, root))
+  compact(map(resources, resource => deserializeResource(resource, included, rootLinks, root)))
 )
 
 export const deserialize = (options = {}) => subject => {


### PR DESCRIPTION
I think it is correct to show empty relationships on the deserialized output. Please think thoroughly about whether I have missed a case in which this would be undesirable behavior.