### PR TITLE
Fix rollup warning messages

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,12 +6,18 @@ export default {
     {
       file: 'dist/compeon-jsonapi-serializer.umd.js',
       name: 'jsonapi-serializer',
-      format: 'umd'
+      format: 'umd',
+      globals: {
+        lodash: 'lodash'
+      }
     },
     {
       file: 'dist/compeon-jsonapi-serializer.es.js',
       name: 'jsonapi-serializer',
-      format: 'es'
+      format: 'es',
+      globals: {
+        lodash: 'lodash'
+      }
     }
   ],
   plugins: [
@@ -21,5 +27,6 @@ export default {
       plugins: ['@babel/plugin-proposal-object-rest-spread'],
       presets: [['@babel/env', { modules: false }]]
     })
-  ]
+  ],
+  external: ['lodash']
 }


### PR DESCRIPTION
Added `externals` and `globals` to rollup to remove warning messages on `yarn build`.

Before:
<img width="686" alt="Bildschirmfoto 2022-03-08 um 10 39 42" src="https://user-images.githubusercontent.com/53489780/157210314-f7ae83bd-8cfe-49c2-bc20-28756209beaa.png">

After:
<img width="691" alt="Bildschirmfoto 2022-03-08 um 10 39 29" src="https://user-images.githubusercontent.com/53489780/157210347-265bd5b6-557f-47fb-a402-abf19b1f412a.png">
